### PR TITLE
Add support for a URI command line invocation in addition to a local file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ $ gem install stackprof-webnav
 ### Pass a dump to it
 ```bash
 $ stackprof-webnav /path/to/stackprof.dump
+$ stackprof-webnav http://path/to/stackprof.dump
 ```
+If the argument passed does not exist locally, it is assumed to be a URI and is treated as such.
 
 See [stackprof gem][create-dump] homepage to learn how to create dumps.
 

--- a/bin/stackprof-webnav
+++ b/bin/stackprof-webnav
@@ -7,7 +7,7 @@ options = {
 }
 
 parser = OptionParser.new(ARGV) do |o|
-  o.banner = "Usage: stackprof-webnav file.dump [-p NUMBER]"
+  o.banner = "Usage: stackprof-webnav file.dump|http://path/to/file.dump [-p NUMBER]"
   o.on('-p [PORT]', 'Server port') {|port| options[:port] = port }
 end
 
@@ -15,7 +15,12 @@ parser.parse!
 parser.abort(parser.help) if ARGV.empty?
 
 file = ARGV.pop
-
 server = StackProf::Webnav::Server
-server.report_dump_path = File.expand_path(file)
+
+if File.exists?(file)
+  server.report_dump_path = File.expand_path(file)
+else
+  server.report_dump_url = file
+end
+
 server.run! options[:port]


### PR DESCRIPTION
@alisnic: First, thanks for writing this tool. Very useful.

I added a bit of code to support passing a URI via the command line instead of a local file. I've got some dumps in an S3 bucket and it was getting tiresome to download them all the time.

Also noticed that the file/URI was getting reread on each navigation through the stack. Added a return if the presenter has already been computed.
