### PR TITLE
Add support for reading/browsing an Amazon S3 bucket containing dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,18 @@ Provides a web ui to inspect stackprof dumps.
 $ gem install stackprof-webnav
 ```
 
-### Pass a dump to it
+### Pass a dump/URI to it
 ```bash
-$ stackprof-webnav /path/to/stackprof.dump
-$ stackprof-webnav http://path/to/stackprof.dump
+$ stackprof-webnav -f /path/to/stackprof.dump
+$ stackprof-webnav -u http://path/to/stackprof.dump
+$ stackprof-webnav -b http://amazon/s3/bucketlisting.xml
 ```
-If the argument passed does not exist locally, it is assumed to be a URI and is treated as such.
 
 See [stackprof gem][create-dump] homepage to learn how to create dumps.
+See [amazon s3 API docs][list-bucket-contents] to see the URI format for S3 bucket listings.
 
 ### Profit
-Open the browser at localhost:9292
+Open the browser at localhost:9292. If you've used the -f or -u form, you can navigate the dump. If you've used the -b form, you'll see a listing of the keys in the bucket -- click on one that is a dump to browse through it.
 
 ## Caveats
 - no tests, this gem was created for my personal usage in a hack stream,
@@ -47,3 +48,4 @@ Open the browser at localhost:9292
 [main-screenshot]: https://github.com/alisnic/stackprof-webnav/blob/master/screenshots/main.png?raw=true
 [method-screenshot]: https://github.com/alisnic/stackprof-webnav/blob/master/screenshots/method.png?raw=true
 [file-screenshot]: https://github.com/alisnic/stackprof-webnav/blob/master/screenshots/file.png?raw=true
+[list-bucket-contents]: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGET.html

--- a/bin/stackprof-webnav
+++ b/bin/stackprof-webnav
@@ -7,20 +7,17 @@ options = {
 }
 
 parser = OptionParser.new(ARGV) do |o|
-  o.banner = "Usage: stackprof-webnav file.dump|http://path/to/file.dump [-p NUMBER]"
+  o.banner = "Usage: stackprof-webnav [-f localfile.dump]|[-u http://path/to/file.dump]|[-b http://path/to/s3/bucket/listing] [-p NUMBER]"
+  o.on('-f [LOCALFILE]', 'Local file path to dump') {|filepath| options[:filepath] = filepath }
+  o.on('-u [URI]', 'URI path to dump') {|uri| options[:uri] = uri }
+  o.on('-b [URI]', 'URI path to Amazon S3 bucket listing') {|bucket| options[:bucket] = bucket}
   o.on('-p [PORT]', 'Server port') {|port| options[:port] = port }
 end
 
 parser.parse!
-parser.abort(parser.help) if ARGV.empty?
+parser.abort(parser.help) unless [:filepath, :uri, :bucket].any? {|key| options.key?(key)} 
 
-file = ARGV.pop
 server = StackProf::Webnav::Server
-
-if File.exists?(file)
-  server.report_dump_path = File.expand_path(file)
-else
-  server.report_dump_url = file
-end
+server.cmd_options = options
 
 server.run! options[:port]

--- a/lib/stackprof-webnav/presenter.rb
+++ b/lib/stackprof-webnav/presenter.rb
@@ -1,5 +1,6 @@
 require 'better_errors'
 require 'stringio'
+require 'rexml/document'
 
 module StackProf
   module Webnav
@@ -31,6 +32,23 @@ module StackProf
             :method => info[:name]
           }
         end
+      end
+
+      def listing_dumps
+        xml_data = Net::HTTP.get(URI.parse(Server.report_dump_listing))
+        if xml_data
+          doc = REXML::Document.new(xml_data)
+          dumps = []
+          doc.elements.each('ListBucketResult/Contents') do |ele|
+            dumps << {
+              :key => ele.elements["Key"].text, 
+              :date => ele.elements["LastModified"].text, 
+              :uri => Server.report_dump_listing + ele.elements["Key"].text
+            }
+          end
+        end
+        dumps.sort_by! { |hash| hash[:date] }
+        dumps.reverse!
       end
 
       def method_info name

--- a/lib/stackprof-webnav/server.rb
+++ b/lib/stackprof-webnav/server.rb
@@ -12,19 +12,33 @@ module StackProf
       config.assets.paths << File.join(__dir__, 'css')
 
       class << self
-        attr_accessor :report_dump_path, :report_dump_url
+        attr_accessor :cmd_options, :report_dump_path, :report_dump_uri, :report_dump_listing 
 
-        def presenter
-          return @presenter unless @presenter.nil?
-          content = if report_dump_path.nil?
-                      Net::HTTP.get(URI.parse(report_dump_url))
-                    else
-                      File.open(report_dump_path).read
-                    end
-
-          report = StackProf::Report.new(Marshal.load(content))
-          @presenter ||= Presenter.new(report)
+        def presenter regenerate=false
+          return @presenter unless regenerate || @presenter.nil?
+          process_options
+          if self.report_dump_path || self.report_dump_uri
+            report_contents = if report_dump_path.nil?
+                                Net::HTTP.get(URI.parse(report_dump_uri)) 
+                              else 
+                                File.open(report_dump_path).read
+                              end
+            report = StackProf::Report.new(Marshal.load(report_contents))
+          end
+          @presenter = Presenter.new(report)
         end
+
+        private
+        def process_options
+          if cmd_options[:filepath]                               
+            self.report_dump_path = cmd_options[:filepath]      
+          elsif cmd_options[:uri]                                 
+            self.report_dump_uri = cmd_options[:uri]            
+          elsif cmd_options[:bucket]
+            self.report_dump_listing = cmd_options[:bucket]
+          end                           
+        end
+                      
       end
 
       helpers do
@@ -48,14 +62,38 @@ module StackProf
         def file_url path
           "/file?path=#{URI.escape(path)}"
         end
+        
+        def overview_url path
+          "/overview?path=#{URI.escape(path)}"
+        end
       end
 
       get '/' do
-        @file = Server.report_dump_path || Server.report_dump_url
+        presenter
+        if Server.report_dump_listing
+          redirect_to '/listing' 
+        else
+          redirect_to '/overview'
+        end
+      end
+
+      get '/overview' do
+        if params[:path]
+          Server.report_dump_uri = params[:path]
+          Server.presenter(true)
+        end
+        @file = Server.report_dump_path || Server.report_dump_uri
         @action = "overview"
         @frames = presenter.overview_frames
         render_with_layout :overview
       end
+
+      get '/listing' do
+        @file = Server.report_dump_listing
+        @action = "listing"
+        @dumps = presenter.listing_dumps 
+        render_with_layout :listing
+      end 
 
       get '/method' do
         @action = params[:name]

--- a/lib/stackprof-webnav/views/listing.haml
+++ b/lib/stackprof-webnav/views/listing.haml
@@ -1,0 +1,21 @@
+%h3 StackProf Navigator
+%hr
+
+%p
+  Viewing S3 bucket at 
+  %b= @file
+
+%table.centered                     
+  %thead                            
+    %th Key                     
+    %th Date                           
+    %th Dump                     
+                                   
+  %tbody                            
+    - @dumps.each do |dump|                       
+      %tr                                           
+        %td= dump[:key]                          
+        %td= dump[:date]                      
+        %td                                         
+          %a{:href => overview_url(dump[:uri])}   
+            = dump[:uri]                        


### PR DESCRIPTION
@alisnic: Here's the support I mention in my last PR for turning an Amazon S3 bucket listing into a browsable page of dumps.

Notable changes:
- Altered the command line syntax -- suggestion is -f for a local dump file, -u for URIs to a dump file and -b for an S3 bucket listing
- Added a .yaml template and corresponding parsing code to deal with the bucket listing
- The "/" route now redirects to either "/overview" or "/listing" depending on which flag was used to start the app.
- Altered the README to match the code.
