### PR TITLE
Fixes: Updated version to 0.0.3 and added size column to bucket listing output

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stackprof-webnav (0.0.2)
+    stackprof-webnav (0.0.3)
       haml (~> 4.0)
       nyny (~> 3.4)
       sprockets-nyny (= 0.0.3)

--- a/lib/stackprof-webnav/presenter.rb
+++ b/lib/stackprof-webnav/presenter.rb
@@ -1,6 +1,8 @@
 require 'better_errors'
 require 'stringio'
 require 'rexml/document'
+require 'action_view'
+include ActionView::Helpers::NumberHelper
 
 module StackProf
   module Webnav
@@ -43,7 +45,8 @@ module StackProf
           doc.elements.each('ListBucketResult/Contents') do |ele|
             dumps << {
               :key => ele.elements["Key"].text, 
-              :date => ele.elements["LastModified"].text, 
+              :date => ele.elements["LastModified"].text,
+              :size => number_with_delimiter(ele.elements["Size"].text.to_i),
               :uri => Server.report_dump_listing + ele.elements["Key"].text
             }
           end

--- a/lib/stackprof-webnav/views/listing.haml
+++ b/lib/stackprof-webnav/views/listing.haml
@@ -9,13 +9,15 @@
   %thead                            
     %th Key                     
     %th Date                           
-    %th Dump                     
+    %th Size
+    %th Dump
                                    
-  %tbody                            
+  %tbody
     - @dumps.each do |dump|                       
       %tr                                           
         %td= dump[:key]                          
         %td= dump[:date]                      
+        %td= dump[:size]
         %td                                         
           %a{:href => overview_url(dump[:uri])}   
             = dump[:uri]                        


### PR DESCRIPTION
@alisnic: Bumping the Gemfile.lock version up one to match the deployed gem and a small improvement to the bucket listing view to include size.
