### PR TITLE
Use double % signs in sprintf for the compatibility of Ruby 2.5 or later

### DIFF
--- a/lib/stackprof-webnav/presenter.rb
+++ b/lib/stackprof-webnav/presenter.rb
@@ -74,7 +74,7 @@ module StackProf
       private
 
       def percent value
-        "%2.2f%" % (value*100)
+        "%2.2f%%" % (value*100)
       end
 
       def callers frame, info


### PR DESCRIPTION
With Ruby 2.5 or later, `'%f%' % 42.0` raises ArgumentError.
`'%f%%' % 42.0` returns `42.0` as expected in any Rubies.