### PR TITLE
Escape HTML in method names

### DIFF
--- a/lib/stackprof-webnav/views/method.haml
+++ b/lib/stackprof-webnav/views/method.haml
@@ -25,7 +25,7 @@
             %td= caller[:pct]
             %td
               %a{:href => url_for("/method", name: caller[:method])}
-                = caller[:method]
+                &= caller[:method]
 
   - if frame[:callees].any?
     %table
@@ -42,7 +42,7 @@
             %td= caller[:pct]
             %td
               %a{:href => url_for("/method", name: caller[:method])}
-                = caller[:method]
+                &= caller[:method]
 
   %h4 Code
   != frame[:source]

--- a/lib/stackprof-webnav/views/overview.haml
+++ b/lib/stackprof-webnav/views/overview.haml
@@ -36,4 +36,4 @@
         %td= frame[:samples_pct]
         %td
           %a{:href => url_for("/method", name: frame[:method])}
-            = frame[:method]
+            &= frame[:method]


### PR DESCRIPTION
For some reason I never quite figured out, sometimes StackProf fails to get the module or class name correctly, and I end up with method names such as `#<Module:0x000056004df18760>.storage_to_output`.

And this end up being interpreted as an HTML tag:

<img width="421" alt="Capture d’écran, le 2020-02-18 à 12 47 20" src="https://user-images.githubusercontent.com/19192189/74733540-d3a4b380-524c-11ea-8685-4aedc267f84b.png">
