### PR TITLE
added a check to avoid setting the current dump to nil for request like the favicon

### DIFF
--- a/lib/stackprof-webnav/server.rb
+++ b/lib/stackprof-webnav/server.rb
@@ -29,7 +29,7 @@ module StackProf
 
       before do
         unless request.path_info == '/'
-          if params[:dump] != current_dump.path
+          if params[:dump] && params[:dump] != current_dump.path
             current_dump.path = params[:dump]
           end
         end


### PR DESCRIPTION
Currently if the browser makes other requests (like requesting a favicon) without a dump specified, then the `current_dump.path` gets set to `nil`. This PR fixes this by only setting the `current_dump.path` if the dump query parameter is present.