### PR TITLE
Facilitate graph navigation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,4 +78,4 @@ DEPENDENCIES
   stackprof-webnav!
 
 BUNDLED WITH
-   1.17.3
+   2.2.18

--- a/bin/stackprof-webnav
+++ b/bin/stackprof-webnav
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 require 'optparse'
-require 'stackprof-webnav'
 require 'rack'
+
+require_relative '../lib/stackprof-webnav'
 
 options = {
   :addr => "127.0.0.1",

--- a/lib/stackprof-webnav.rb
+++ b/lib/stackprof-webnav.rb
@@ -1,1 +1,1 @@
-require 'stackprof-webnav/server'
+require_relative 'stackprof-webnav/server'

--- a/lib/stackprof-webnav/dump.rb
+++ b/lib/stackprof-webnav/dump.rb
@@ -36,6 +36,6 @@ class Dump
   end
 
   def graph_image_path
-    @path + ".#{checksum}.graph.png"
+    @path + ".#{checksum}.graph.svg"
   end
 end

--- a/lib/stackprof-webnav/public/css/application.css
+++ b/lib/stackprof-webnav/public/css/application.css
@@ -5,3 +5,14 @@ table {
 pre code {
   color: black;
 }
+
+#graph > a {
+  position: absolute;
+}
+#graph > div {
+  overflow: scroll;
+  height: 100%;
+}
+#graph > div > img {
+  max-width: initial;
+}

--- a/lib/stackprof-webnav/server.rb
+++ b/lib/stackprof-webnav/server.rb
@@ -1,10 +1,10 @@
 require 'sinatra'
 require 'haml'
-require "stackprof"
+require 'stackprof'
 require_relative 'presenter'
 require_relative 'dump'
 require 'pry'
-require "sinatra/reloader" if development?
+require 'sinatra/reloader' if development?
 require 'ruby-graphviz'
 
 module StackProf
@@ -103,7 +103,7 @@ module StackProf
         send_file(current_dump.flame_graph_path, type: 'text/javascript')
       end
 
-      get '/graph.png' do
+      get '/graph.svg' do
         ensure_file_generated(current_dump.graph_path) do |file|
           current_report.print_graphviz({}, file)
         end
@@ -111,10 +111,10 @@ module StackProf
         ensure_file_generated(current_dump.graph_image_path) do |file|
           GraphViz
             .parse(current_dump.graph_path)
-            .output(png: current_dump.graph_image_path)
+            .output(svg: current_dump.graph_image_path)
         end
 
-        send_file(current_dump.graph_image_path, type: 'image/png')
+        send_file(current_dump.graph_image_path, type: 'image/svg+xml')
       end
 
       get '/graph' do

--- a/lib/stackprof-webnav/views/graph.haml
+++ b/lib/stackprof-webnav/views/graph.haml
@@ -1,4 +1,5 @@
-%a{:href => url_for("/overview")}
-  %button Back to overview
-
-%img{src: url_for("/graph.png")}
+#graph
+  %a{:href => url_for("/overview")}
+    %button Back to overview
+  %div
+    %img{src: url_for("/graph.svg")}

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "integration tests" do
   after(:each) do
     Dir.glob("spec/fixtures/*.flames.json").each {|file| File.delete(file) }
     Dir.glob("spec/fixtures/*.digraph.dot").each {|file| File.delete(file) }
-    Dir.glob("spec/fixtures/*.graph.png").each {|file| File.delete(file) }
+    Dir.glob("spec/fixtures/*.graph.svg").each {|file| File.delete(file) }
   end
 
   describe "index" do
@@ -55,8 +55,8 @@ RSpec.describe "integration tests" do
   end
 
   it "is able to render graph" do
-    app.get "/graph.png", dump: fixture_path("test.dump")
-    expect(response.get_header("Content-Type")).to eq("image/png")
+    app.get "/graph.svg", dump: fixture_path("test.dump")
+    expect(response.get_header("Content-Type")).to eq("image/svg+xml")
     expect(response.body.size).to_not eq(0)
   end
 


### PR DESCRIPTION

![example](https://user-images.githubusercontent.com/11378424/119778721-25180580-bec8-11eb-9272-56779de0f728.gif)

- Replace png with svg for big stacks, which improves both lisibility
  and file size (test.dump image changed is divided by 5).
- Add a bit of css to keep image at max size and allow scrolling while
  keeping the _Back to overview_ button visible.
- SIDE: Use require_relative rather than require when in project to make
  sure we are not working with the globally installed stack.

---

Hi,

Thanks for the great tool, it has proven to be very useful for me! I'd like to contribute back by adding something that was mandatory for me when using the tool: svg image rather than png.

The contribution is a bit opiniated, hence feel free to tell me if you want any change.

Cheers,
Ulysse
