### PR TITLE
Relax dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,11 @@ PATH
   remote: .
   specs:
     stackprof-webnav (1.0.2)
-      better_errors (~> 1.1.0)
-      haml (~> 5.1.2)
-      ruby-graphviz (~> 1.2.4)
-      sinatra (~> 2.0.7)
-      sinatra-contrib (~> 2.0.5)
+      better_errors (>= 1.1.0)
+      haml (>= 5.1.2)
+      ruby-graphviz (>= 1.2.4)
+      sinatra (>= 2.0.7)
+      sinatra-contrib (>= 2.0.5)
       stackprof (>= 0.2.13)
 
 GEM

--- a/stackprof-webnav.gemspec
+++ b/stackprof-webnav.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |spec|
   spec.bindir = 'bin'
   spec.executables << 'stackprof-webnav'
 
-  spec.add_dependency "sinatra", "~> 2.0.7"
-  spec.add_dependency "haml", "~> 5.1.2"
+  spec.add_dependency "sinatra", ">= 2.0.7"
+  spec.add_dependency "haml", ">= 5.1.2"
   spec.add_dependency "stackprof", ">= 0.2.13"
-  spec.add_dependency "better_errors", "~> 1.1.0"
-  spec.add_dependency "ruby-graphviz", "~> 1.2.4"
-  spec.add_dependency "sinatra-contrib", "~> 2.0.5"
+  spec.add_dependency "better_errors", ">= 1.1.0"
+  spec.add_dependency "ruby-graphviz", ">= 1.2.4"
+  spec.add_dependency "sinatra-contrib", ">= 2.0.5"
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 10.1"
   spec.add_development_dependency "rspec", "~> 3.9.0"


### PR DESCRIPTION
I want to use `stackprof-webnav` and `sinatra` v2.1.0, but I couldn't install due to the error below. 

```ruby
# Gemfile
gem "sinatra", "2.1.0"
gem "sinatra-contrib", "2.1.0"
gem "stackprof", "0.2.17"
gem "stackprof-webnav", "1.0.2"
```

```bash
$ bundle install
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Bundler could not find compatible versions for gem "sinatra":
  In snapshot (Gemfile.lock):
    sinatra (= 2.1.0)

  In Gemfile:
    sinatra-contrib (= 2.1.0) was resolved to 2.1.0, which depends on
      sinatra (= 2.1.0)

    stackprof-webnav (= 1.0.2) was resolved to 1.0.2, which depends on
      sinatra (~> 2.0.7)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

So I relaxed.