### PR TITLE
Stopped requiring `pry`

### DIFF
--- a/lib/stackprof-webnav/server.rb
+++ b/lib/stackprof-webnav/server.rb
@@ -3,7 +3,6 @@ require 'haml'
 require 'stackprof'
 require_relative 'presenter'
 require_relative 'dump'
-require 'pry'
 require 'sinatra/reloader' if development?
 require 'ruby-graphviz'
 


### PR DESCRIPTION
`pry` is required [here](https://github.com/alisnic/stackprof-webnav/blob/v1.0.2/lib/stackprof-webnav/server.rb#L6), but `pry` isn't in runtime dependency

https://github.com/alisnic/stackprof-webnav/blob/v1.0.2/stackprof-webnav.gemspec#L24-L29

Therefore, an error will occur at startup if `pry` isn't in `Gemfile`

```
bundler: failed to load command: stackprof-webnav (/app/vendor/bundle/ruby/3.0.0/bin/stackprof-webnav)
/app/vendor/bundle/ruby/3.0.0/gems/stackprof-webnav-1.0.2/lib/stackprof-webnav/server.rb:6:in `require': cannot load such file -- pry (LoadError)

Did you mean?  pty
        from /app/vendor/bundle/ruby/3.0.0/gems/stackprof-webnav-1.0.2/lib/stackprof-webnav/server.rb:6:in `<top (required)>'
        from /app/vendor/bundle/ruby/3.0.0/gems/stackprof-webnav-1.0.2/lib/stackprof-webnav.rb:1:in `require_relative'
        from /app/vendor/bundle/ruby/3.0.0/gems/stackprof-webnav-1.0.2/lib/stackprof-webnav.rb:1:in `<top (required)>'
        from /app/vendor/bundle/ruby/3.0.0/gems/stackprof-webnav-1.0.2/bin/stackprof-webnav:5:in `require_relative'
        from /app/vendor/bundle/ruby/3.0.0/gems/stackprof-webnav-1.0.2/bin/stackprof-webnav:5:in `<top (required)>'
        from /app/vendor/bundle/ruby/3.0.0/bin/stackprof-webnav:23:in `load'
        from /app/vendor/bundle/ruby/3.0.0/bin/stackprof-webnav:23:in `<top (required)>'
```

So I stopped requiring `pry`

ref. #26 