### PR TITLE
Add webrick to runtime dependency

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7']
+        ruby-version:
+          - '2.7'
+          - '3.0'
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
       sinatra (~> 2.0.7)
       sinatra-contrib (~> 2.0.5)
       stackprof (>= 0.2.13)
+      webrick (~> 1.7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -67,6 +68,7 @@ GEM
     stackprof (0.2.17)
     temple (0.8.2)
     tilt (2.0.10)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby

--- a/stackprof-webnav.gemspec
+++ b/stackprof-webnav.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "better_errors", "~> 1.1.0"
   spec.add_dependency "ruby-graphviz", "~> 1.2.4"
   spec.add_dependency "sinatra-contrib", "~> 2.0.5"
-  spec.add_dependency "webrick"
+  spec.add_dependency "webrick", "~> 1.7.0"
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 10.1"
   spec.add_development_dependency "rspec", "~> 3.9.0"

--- a/stackprof-webnav.gemspec
+++ b/stackprof-webnav.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "better_errors", "~> 1.1.0"
   spec.add_dependency "ruby-graphviz", "~> 1.2.4"
   spec.add_dependency "sinatra-contrib", "~> 2.0.5"
+  spec.add_dependency "webrick"
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 10.1"
   spec.add_development_dependency "rspec", "~> 3.9.0"


### PR DESCRIPTION
`webrick` is removed from default gem since ruby 3.0.0

https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

Therefore, an error will occur at startup if `webrick` isn't in `Gemfile`

```
bundler: failed to load command: stackprof-webnav (/app/vendor/bundle/ruby/3.0.0/bin/stackprof-webnav)
/app/vendor/bundle/ruby/3.0.0/gems/rack-2.2.3/lib/rack/handler.rb:45:in `pick': Couldn't find handler for: thin, webrick. (LoadError)
        from /app/vendor/bundle/ruby/3.0.0/gems/stackprof-webnav-1.0.2/bin/stackprof-webnav:25:in `<top (required)>'
        from /app/vendor/bundle/ruby/3.0.0/bin/stackprof-webnav:23:in `load'
        from /app/vendor/bundle/ruby/3.0.0/bin/stackprof-webnav:23:in `<top (required)>'
```

So I added this.

I think this patch conflicts with #29
I plan to resolve the conflict and push after the #29 has been merged.