### PR TITLE
Removed .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: ruby
-script: bundle exec rspec
-before_install:
-  - "sudo apt-get install graphviz"


### PR DESCRIPTION
This repository has already been migrated to GitHub Actions so no `.travis.yml` is needed.

So I removed this.