### PR TITLE
Upgrade to sinatra v2.1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,15 +5,14 @@ PATH
       better_errors (~> 1.1.0)
       haml (~> 5.1.2)
       ruby-graphviz (~> 1.2.4)
-      sinatra (~> 2.0.7)
-      sinatra-contrib (~> 2.0.5)
+      sinatra (~> 2.1.0)
+      sinatra-contrib (~> 2.1.0)
       stackprof (>= 0.2.13)
       webrick (~> 1.7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    backports (3.21.0)
     better_errors (1.1.0)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -30,8 +29,8 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (2.0.8)
-    rack-protection (2.0.8.1)
+    rack (2.2.3)
+    rack-protection (2.1.0)
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -53,17 +52,16 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby2_keywords (0.0.4)
-    sinatra (2.0.8.1)
+    sinatra (2.1.0)
       mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.8.1)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
       tilt (~> 2.0)
-    sinatra-contrib (2.0.8.1)
-      backports (>= 2.8.2)
+    sinatra-contrib (2.1.0)
       multi_json
       mustermann (~> 1.0)
-      rack-protection (= 2.0.8.1)
-      sinatra (= 2.0.8.1)
+      rack-protection (= 2.1.0)
+      sinatra (= 2.1.0)
       tilt (~> 2.0)
     stackprof (0.2.17)
     temple (0.8.2)

--- a/stackprof-webnav.gemspec
+++ b/stackprof-webnav.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |spec|
   spec.bindir = 'bin'
   spec.executables << 'stackprof-webnav'
 
-  spec.add_dependency "sinatra", "~> 2.0.7"
+  spec.add_dependency "sinatra", "~> 2.1.0"
   spec.add_dependency "haml", "~> 5.1.2"
   spec.add_dependency "stackprof", ">= 0.2.13"
   spec.add_dependency "better_errors", "~> 1.1.0"
   spec.add_dependency "ruby-graphviz", "~> 1.2.4"
-  spec.add_dependency "sinatra-contrib", "~> 2.0.5"
+  spec.add_dependency "sinatra-contrib", "~> 2.1.0"
   spec.add_dependency "webrick", "~> 1.7.0"
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 10.1"


### PR DESCRIPTION
`sinatra` v2.0.x doesn't work on ruby 3.0

```
/home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/mustermann-1.1.1/lib/mustermann.rb:73:in `new': Hash can't be coerced into Mustermann::Pattern (TypeError)
        from /home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/mustermann-1.1.1/lib/mustermann.rb:70:in `block in new'
        from /home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/mustermann-1.1.1/lib/mustermann.rb:70:in `map'
        from /home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/mustermann-1.1.1/lib/mustermann.rb:70:in `new'
        from /home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/sinatra-2.0.7/lib/sinatra/base.rb:1641:in `compile'
        from /home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/sinatra-2.0.7/lib/sinatra/base.rb:1629:in `compile!'
        from /home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/sinatra-2.0.7/lib/sinatra/base.rb:1271:in `error'
        from /home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/sinatra-2.0.7/lib/sinatra/base.rb:1831:in `<class:Base>'
        from /home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/sinatra-2.0.7/lib/sinatra/base.rb:889:in `<module:Sinatra>'
        from /home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/sinatra-2.0.7/lib/sinatra/base.rb:22:in `<top (required)>'
        from <internal:/home/deploy/local/ruby/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:/home/deploy/local/ruby/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from /home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/sinatra-2.0.7/lib/sinatra/main.rb:26:in `<module:Sinatra>'
        from /home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/sinatra-2.0.7/lib/sinatra/main.rb:1:in `<top (required)>'
        from <internal:/home/deploy/local/ruby/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:/home/deploy/local/ruby/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from /home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/sinatra-2.0.7/lib/sinatra.rb:1:in `<top (required)>'
        from <internal:/home/deploy/local/ruby/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:/home/deploy/local/ruby/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from /home/deploy/local/ruby/lib/ruby/gems/3.0.0/gems/stackprof-webnav-1.0.2/lib/stackprof-webnav/server.rb:1:in `<top (required)>'
```

This problem is resolved at `sinatra` v2.1.0

ref. 

* https://github.com/sinatra/sinatra/blob/master/CHANGELOG.md#210--2020-09-05
* https://github.com/sinatra/sinatra/pull/1586
* https://github.com/sinatra/sinatra/pull/1581

So I want to upgrade.