### PR TITLE
upgrade better_errors from 1.1.0 to 2.8.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     stackprof-webnav (1.0.3)
-      better_errors (~> 1.1.0)
+      better_errors (~> 2.8.3)
       haml (~> 5.1.2)
       ruby-graphviz (~> 1.2.4)
       sinatra (~> 2.1.0)
@@ -13,12 +13,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    better_errors (1.1.0)
+    better_errors (2.8.3)
       coderay (>= 1.0.0)
-      erubis (>= 2.6.6)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     coderay (1.1.2)
     diff-lcs (1.3)
-    erubis (2.7.0)
+    erubi (1.10.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -80,4 +81,4 @@ DEPENDENCIES
   stackprof-webnav!
 
 BUNDLED WITH
-   2.2.18
+   2.2.27

--- a/stackprof-webnav.gemspec
+++ b/stackprof-webnav.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sinatra", "~> 2.1.0"
   spec.add_dependency "haml", "~> 5.1.2"
   spec.add_dependency "stackprof", ">= 0.2.13"
-  spec.add_dependency "better_errors", "~> 1.1.0"
+  spec.add_dependency "better_errors", "~> 2.8.3"
   spec.add_dependency "ruby-graphviz", "~> 1.2.4"
   spec.add_dependency "sinatra-contrib", "~> 2.1.0"
   spec.add_dependency "webrick", "~> 1.7.0"


### PR DESCRIPTION
`better_errors` has been upgrade to resolve CVE-2021-39197.