### PR TITLE
Relax webrick and rack version requirements

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,11 +4,12 @@ PATH
     stackprof-webnav (1.0.3)
       better_errors (~> 1.1.0)
       haml (~> 5.1.2)
+      rackup (>= 1.0.0, < 3.0.0)
       ruby-graphviz (~> 1.2.4)
-      sinatra (~> 2.1.0)
-      sinatra-contrib (~> 2.1.0)
+      sinatra (>= 2.1.0, < 5.0.0)
+      sinatra-contrib (>= 2.1.0, < 5.0.0)
       stackprof (>= 0.2.13)
-      webrick (~> 1.7.0)
+      webrick (~> 1.7)
 
 GEM
   remote: https://rubygems.org/
@@ -34,6 +35,9 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rackup (1.0.0)
+      rack (< 3)
+      webrick
     rake (10.5.0)
     rexml (3.2.5)
     rspec (3.9.0)
@@ -74,7 +78,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.2)
   pry
-  rack-test (~> 1.1.0)
+  rack-test (>= 1.1.0, < 3.0.0)
   rake (~> 10.1)
   rspec (~> 3.9.0)
   stackprof-webnav!

--- a/stackprof-webnav.gemspec
+++ b/stackprof-webnav.gemspec
@@ -21,15 +21,16 @@ Gem::Specification.new do |spec|
   spec.bindir = 'bin'
   spec.executables << 'stackprof-webnav'
 
-  spec.add_dependency "sinatra", "~> 2.1.0"
+  spec.add_dependency "sinatra", ">= 2.1.0", "< 5.0.0"
   spec.add_dependency "haml", "~> 5.1.2"
   spec.add_dependency "stackprof", ">= 0.2.13"
   spec.add_dependency "better_errors", "~> 1.1.0"
+  spec.add_dependency "rackup", ">= 1.0.0", "< 3.0.0"
   spec.add_dependency "ruby-graphviz", "~> 1.2.4"
-  spec.add_dependency "sinatra-contrib", "~> 2.1.0"
-  spec.add_dependency "webrick", "~> 1.7.0"
+  spec.add_dependency "sinatra-contrib", ">= 2.1.0", "< 5.0.0"
+  spec.add_dependency "webrick", "~> 1.7"
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 10.1"
   spec.add_development_dependency "rspec", "~> 3.9.0"
-  spec.add_development_dependency "rack-test", "~> 1.1.0"
+  spec.add_development_dependency "rack-test", ">= 1.1.0", "< 3.0.0"
 end


### PR DESCRIPTION
This started with me simply wanting to allow `webrick` 1.8.x, as it is blocking me upgrading other gems in a project. However, significant changes with Rack 3 and Sinatra 4 meant I needed to relax a bunch of other version requirements. 

Techincally, we could drop the `webrick` line, as it is included by `rackup`. Rackup is needed for newer versions of Sinatra, and won't affect older versions.